### PR TITLE
Fix missing multiline CollapsingToolbar dependency issue. #13

### DIFF
--- a/UI/build.gradle
+++ b/UI/build.gradle
@@ -49,4 +49,5 @@ dependencies {
     compile 'org.dmfs:jems:1.8'
     compile 'com.android.support:cardview-v7:25.3.1'
     compile 'me.relex:circleindicator:1.2.1@aar'
+    compile 'com.github.dmfs:multiline-collapsingtoolbar:79a3e45'
 }

--- a/UI/src/main/java/org/dmfs/webcal/EventsPreviewActivity.java
+++ b/UI/src/main/java/org/dmfs/webcal/EventsPreviewActivity.java
@@ -22,12 +22,13 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.design.widget.AppBarLayout;
-import android.support.design.widget.CollapsingToolbarLayout;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v7.app.ActionBar;
 import android.support.v7.widget.Toolbar;
 import android.view.MenuItem;
+
+import net.opacapp.multilinecollapsingtoolbar.CollapsingToolbarLayout;
 
 import org.dmfs.android.retentionmagic.annotations.Parameter;
 import org.dmfs.webcal.IBillingActivity.OnInventoryListener;


### PR DESCRIPTION
I ended up using the dmfs fork version of the multilinecollapsing toolbar, it doesn't even require proguard rules. 