### PR TITLE
Fix calendary sync switch UX flow for first time use (when permission…

### DIFF
--- a/UI/build.gradle
+++ b/UI/build.gradle
@@ -46,4 +46,5 @@ dependencies {
     compile 'com.android.support:cardview-v7:25.3.1'
     compile 'me.relex:circleindicator:1.2.1@aar'
     compile 'com.github.dmfs:multiline-collapsingtoolbar:79a3e45'
+    compile 'org.dmfs:essentials:1.10'
 }

--- a/UI/src/main/java/org/dmfs/webcal/fragments/CalendarItemFragment.java
+++ b/UI/src/main/java/org/dmfs/webcal/fragments/CalendarItemFragment.java
@@ -22,14 +22,14 @@ import android.app.Activity;
 import android.content.ContentUris;
 import android.content.ContentValues;
 import android.content.Context;
-import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Handler;
-import android.support.v4.app.ActivityCompat;
+import android.support.annotation.NonNull;
+import android.support.design.widget.Snackbar;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v4.app.LoaderManager;
@@ -71,11 +71,14 @@ import org.dmfs.webcal.adapters.EventListAdapter;
 import org.dmfs.webcal.adapters.SectionTitlesAdapter;
 import org.dmfs.webcal.adapters.SectionTitlesAdapter.SectionIndexer;
 import org.dmfs.webcal.fragments.CalendarTitleFragment.SwitchStatusListener;
+import org.dmfs.webcal.utils.AppSettingsIntent;
 import org.dmfs.webcal.utils.Event;
 import org.dmfs.webcal.utils.ProtectedBackgroundJob;
 
 import java.net.URI;
 import java.util.TimeZone;
+
+import static android.content.pm.PackageManager.PERMISSION_DENIED;
 
 
 public class CalendarItemFragment extends SubscribeableItemFragment implements LoaderManager.LoaderCallbacks<Cursor>, SwitchStatusListener, OnItemClickListener
@@ -102,6 +105,7 @@ public class CalendarItemFragment extends SubscribeableItemFragment implements L
     private final static String[] PROJECTION = new String[] {
             CalendarContentContract.ContentItem.TITLE, CalendarContentContract.ContentItem.ICON_ID,
             CalendarContentContract.ContentItem.URL, ContentItem.STARRED, ContentItem._ID };
+    private static final int PERMISSION_REQUEST_CODE = 123;
     private final Place mWaitingForCalendarItem = new Place(1);
     private final Place mWaitingForCalendarSubscription = new Place(1);
     private final Place mWaitingForPayment = new Place(1);
@@ -218,7 +222,7 @@ public class CalendarItemFragment extends SubscribeableItemFragment implements L
             if (cursor != null && cursor.moveToFirst())
             {
                 /*
-				 * We have an item.
+                 * We have an item.
 				 * 
 				 * Get the values and update the UI as good as we can.
 				 */
@@ -610,9 +614,6 @@ public class CalendarItemFragment extends SubscribeableItemFragment implements L
     }
 
 
-    ;
-
-
     @Override
     public void onPurchase(boolean success, boolean freeTrial)
     {
@@ -633,8 +634,8 @@ public class CalendarItemFragment extends SubscribeableItemFragment implements L
                 || ContextCompat.checkSelfPermission(getContext(), Manifest.permission.WRITE_CALENDAR) != PackageManager.PERMISSION_GRANTED
                 || ContextCompat.checkSelfPermission(getContext(), Manifest.permission.GET_ACCOUNTS) != PackageManager.PERMISSION_GRANTED)
         {
-            ActivityCompat.requestPermissions(getActivity(),
-                    new String[] { Manifest.permission.WRITE_CALENDAR, Manifest.permission.READ_CALENDAR, Manifest.permission.GET_ACCOUNTS }, 1);
+            requestPermissions(new String[] { Manifest.permission.WRITE_CALENDAR, Manifest.permission.READ_CALENDAR, Manifest.permission.GET_ACCOUNTS },
+                    PERMISSION_REQUEST_CODE);
             return;
         }
 
@@ -687,13 +688,33 @@ public class CalendarItemFragment extends SubscribeableItemFragment implements L
 
 
     @Override
-    public void onActivityResult(int requestCode, int resultCode, Intent data)
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults)
     {
-        if (requestCode == 1 && resultCode == Activity.RESULT_OK)
+        if (requestCode == PERMISSION_REQUEST_CODE)
         {
-            setCalendarSynced(true);
+            if (contains(grantResults, PERMISSION_DENIED))
+            {
+                mTitleFragment.setSwitchChecked(false);
+                if (wasAnyDeniedWithDontAskAgain(permissions, grantResults))
+                {
+                    // UX similar as suggested here: https://youtu.be/iZqDdvhTZj0?t=4m42s
+                    Snackbar.make(getView(), R.string.calendar_sync_permission_denied_message, Snackbar.LENGTH_LONG)
+                            .setAction(R.string.calendar_sync_permission_denied_message_action_label, new View.OnClickListener()
+                            {
+                                @Override
+                                public void onClick(View v)
+                                {
+                                    startActivity(new AppSettingsIntent(getContext()).value());
+                                }
+                            }).show();
+                }
+            }
+            else
+            {
+                mTitleFragment.setSwitchChecked(true);
+                setCalendarSynced(true);
+            }
         }
-        super.onActivityResult(requestCode, resultCode, data);
     }
 
 
@@ -781,11 +802,39 @@ public class CalendarItemFragment extends SubscribeableItemFragment implements L
      */
     private interface COLUMNS
     {
+
         int TITLE = 0;
+
         int ICON = 1;
         int URL = 2;
         int STARRED = 3;
         @SuppressWarnings("unused")
         int ID = 4;
+    }
+
+
+    private boolean contains(int[] array, int item)
+    {
+        for (int element : array)
+        {
+            if (element == item)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+
+    private boolean wasAnyDeniedWithDontAskAgain(String[] permissions, int[] grantResults)
+    {
+        for (int i = 0; i < permissions.length; i++)
+        {
+            if (grantResults[i] == PERMISSION_DENIED && !shouldShowRequestPermissionRationale(permissions[i]))
+            {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/UI/src/main/java/org/dmfs/webcal/utils/AppSettingsIntent.java
+++ b/UI/src/main/java/org/dmfs/webcal/utils/AppSettingsIntent.java
@@ -1,0 +1,38 @@
+package org.dmfs.webcal.utils;
+
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+import android.provider.Settings;
+
+import org.dmfs.jems.single.Single;
+
+
+/**
+ * {@link Single} for an {@link Intent} that opens the app's settings screen in the device settings.
+ * <p>
+ * See: https://stackoverflow.com/a/32983128/4247460
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class AppSettingsIntent implements Single<Intent>
+{
+    private final Context mContext;
+
+
+    public AppSettingsIntent(Context context)
+    {
+        mContext = context.getApplicationContext();
+    }
+
+
+    @Override
+    public Intent value()
+    {
+        Intent intent = new Intent();
+        intent.setAction(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
+        Uri uri = Uri.fromParts("package", mContext.getPackageName(), null);
+        intent.setData(uri);
+        return intent;
+    }
+}

--- a/UI/src/main/res/values/strings.xml
+++ b/UI/src/main/res/values/strings.xml
@@ -158,4 +158,9 @@
     <string name="menu_favorite">Mark favorite</string>
     <string name="menu_settings_short">Settings</string>
     <string name="menu_settings">Open calendar settings</string>
+
+    <!-- Message when permissions had been denied with 'not show again' but they would be needed for enabling Calendar synchronisation-->
+    <string name="calendar_sync_permission_denied_message">Calendar synchronisation requires Calendar and Contact permissions.</string>
+    <!-- The action button label for the message above, to prompt the user to open app settings in device settings to update permissions -->
+    <string name="calendar_sync_permission_denied_message_action_label">Settings</string>
 </resources>


### PR DESCRIPTION
… is requested). #22

---

`onRequestPermissionsResult()` callback is now handled to update the sync state after the permission request. I've also added a Snackbar message to point to the device settings when permission is denied with 'don't show again'. It's based on this answer and the video referred in it: https://stackoverflow.com/a/32983128/4247460