### PR TITLE
Remove GET_ACCOUNTS permission requirement on Android M+ versions. #25

### DIFF
--- a/UI/src/main/AndroidManifest.xml
+++ b/UI/src/main/AndroidManifest.xml
@@ -5,13 +5,11 @@
         android:versionCode="106"
         android:versionName="1">
 
-    <uses-sdk
-            android:minSdkVersion="14"
-            android:targetSdkVersion="21"/>
-
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="com.android.vending.BILLING"/>
-    <uses-permission android:name="android.permission.GET_ACCOUNTS"/>
+    <uses-permission
+            android:name="android.permission.GET_ACCOUNTS"
+            android:maxSdkVersion="22"/>
     <uses-permission android:name="android.permission.USE_CREDENTIALS"/>
     <uses-permission android:name="android.permission.MANAGE_ACCOUNTS"/>
     <uses-permission android:name="android.permission.AUTHENTICATE_ACCOUNTS"/>

--- a/UI/src/main/java/org/dmfs/webcal/fragments/CalendarItemFragment.java
+++ b/UI/src/main/java/org/dmfs/webcal/fragments/CalendarItemFragment.java
@@ -17,12 +17,10 @@
 
 package org.dmfs.webcal.fragments;
 
-import android.Manifest;
 import android.app.Activity;
 import android.content.ContentUris;
 import android.content.ContentValues;
 import android.content.Context;
-import android.content.pm.PackageManager;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.AsyncTask;
@@ -80,7 +78,10 @@ import org.dmfs.webcal.utils.color.ResourceColor;
 import java.net.URI;
 import java.util.TimeZone;
 
+import static android.Manifest.permission.READ_CALENDAR;
+import static android.Manifest.permission.WRITE_CALENDAR;
 import static android.content.pm.PackageManager.PERMISSION_DENIED;
+import static android.content.pm.PackageManager.PERMISSION_GRANTED;
 
 
 public class CalendarItemFragment extends SubscribeableItemFragment implements LoaderManager.LoaderCallbacks<Cursor>, SwitchStatusListener, OnItemClickListener
@@ -634,12 +635,11 @@ public class CalendarItemFragment extends SubscribeableItemFragment implements L
 
     private void setCalendarSynced(final boolean status)
     {
-        if (status && (ContextCompat.checkSelfPermission(getContext(), Manifest.permission.READ_CALENDAR) != PackageManager.PERMISSION_GRANTED)
-                || ContextCompat.checkSelfPermission(getContext(), Manifest.permission.WRITE_CALENDAR) != PackageManager.PERMISSION_GRANTED
-                || ContextCompat.checkSelfPermission(getContext(), Manifest.permission.GET_ACCOUNTS) != PackageManager.PERMISSION_GRANTED)
+        if (status &&
+                (ContextCompat.checkSelfPermission(getContext(), READ_CALENDAR) != PERMISSION_GRANTED
+                        || ContextCompat.checkSelfPermission(getContext(), WRITE_CALENDAR) != PERMISSION_GRANTED))
         {
-            requestPermissions(new String[] { Manifest.permission.WRITE_CALENDAR, Manifest.permission.READ_CALENDAR, Manifest.permission.GET_ACCOUNTS },
-                    PERMISSION_REQUEST_CODE);
+            requestPermissions(new String[] { READ_CALENDAR, WRITE_CALENDAR }, PERMISSION_REQUEST_CODE);
             return;
         }
 

--- a/UI/src/main/res/values/strings.xml
+++ b/UI/src/main/res/values/strings.xml
@@ -160,7 +160,7 @@
     <string name="menu_settings">Open calendar settings</string>
 
     <!-- Message when permissions had been denied with 'not show again' but they would be needed for enabling Calendar synchronisation-->
-    <string name="calendar_sync_permission_denied_message">Calendar synchronisation requires Calendar and Contact permissions.</string>
+    <string name="calendar_sync_permission_denied_message">Calendar synchronisation requires Calendar permission.</string>
     <!-- The action button label for the message above, to prompt the user to open app settings in device settings to update permissions -->
     <string name="calendar_sync_permission_denied_message_action_label">Settings</string>
 </resources>


### PR DESCRIPTION

Note: At first I way over complicated this because I thought we need to handle the difference runtime, didn't realize that 23+ is the same level from where runtime permission is needed at all, so we don't need to required it. After that, the change is pretty simple.